### PR TITLE
refactor: use dataclient members to set filters/predicates via Options

### DIFF
--- a/fabric/dataclient.go
+++ b/fabric/dataclient.go
@@ -176,12 +176,6 @@ type Options struct {
 	LogUserFilter                string
 	FlowIDFilter                 string
 
-	CheckEmployeeFilterArgs          []interface{}
-	CheckServiceFilterArgs           []interface{}
-	CheckEmployeeOrServiceFilterArgs []interface{}
-	CheckCommonScopeFilterArgs       []interface{}
-	LogCommonKeyFilterArgs           []interface{}
-
 	// ClusterClientRatelimitHeader is used for identifying a
 	// client in a given request
 	ClusterClientRatelimitHeader string
@@ -384,7 +378,7 @@ func (c *clusterClient) loadFabricgateways() ([]*Fabric, error) {
 
 func configureFilters(s string, defaultFilter *eskip.Filter) []*eskip.Filter {
 	if s == "" {
-		log.Infof("configureFilters fallback to default %s", defaultFilter)
+		log.Debugf("configureFilters fallback to default %s", defaultFilter)
 		return []*eskip.Filter{defaultFilter}
 	}
 	target, err := eskip.ParseFilters(s)

--- a/fabric/fabrictest/fixtures.go
+++ b/fabric/fabrictest/fixtures.go
@@ -182,6 +182,23 @@ func testFixture(t *testing.T, f fixtureSet) {
 
 	o := fabric.Options{
 		KubernetesURL: s.URL,
+
+		// keep everything defaults
+		// filters
+		CheckEmployeeFilter:          "",
+		CheckServiceFilter:           "",
+		CheckEmployeeOrServiceFilter: "",
+		CheckCommonScopeFilter:       "",
+		LogServiceFilter:             "",
+		LogUserFilter:                "",
+		ForwardTokenServiceFilter:    "",
+		ForwardTokenEmployeeFilter:   "",
+		FlowIDFilter:                 "",
+		// rest
+		ClusterClientRatelimitHeader: "",
+		UidKey:                       "",
+		UserListPredicate:            "",
+		UserRealmPredicate:           "",
 	}
 	c, err := fabric.NewFabricDataClient(o)
 	if err != nil {

--- a/fabric/testdata/feature/feature-employee-access.eskip
+++ b/fabric/testdata/feature/feature-employee-access.eskip
@@ -40,7 +40,7 @@ fg_default_feature_employee_access_feature_employee_access_example_org__api_seco
 	-> forwardToken("X-TokenInfo-Forward", "uid", "scope", "realm")
 	-> <roundRobin, "http://10.2.23.42:8080", "http://10.2.5.4:8080">;
 
-fg_eaccess_default_feature_employee_access_feature_employee_access_example_org__api_secondary_resource_get: Path("/api/secondary-resource") && Method("GET") && HostAny("feature-employee-access.example.org", "feature-employee-access.example.org:443") && Header("X-Forwarded-Proto", "https") && Weight(4) && JWTPayloadAllKV("https://identity.zalando.com/realm", "users")
+fg_eaccess_default_feature_employee_access_feature_employee_access_example_org__api_secondary_resource_get: Path("/api/secondary-resource") && Method("GET") && HostAny("feature-employee-access.example.org", "feature-employee-access.example.org:443") && Header("X-Forwarded-Proto", "https") && Weight(4) && JWTPayloadAnyKV("https://identity.zalando.com/realm", "users")
 	-> oauthTokeninfoAnyKV("realm", "/employees")
 	-> oauthTokeninfoAllScope("uid")
 	-> unverifiedAuditLog("sub")
@@ -56,7 +56,7 @@ fg_default_feature_employee_access_feature_employee_access_example_org__api_thir
 	-> forwardToken("X-TokenInfo-Forward", "uid", "scope", "realm")
 	-> <roundRobin, "http://10.2.23.42:8080", "http://10.2.5.4:8080">;
 
-fg_eaccess_default_feature_employee_access_feature_employee_access_example_org__api_third_resource_get: Path("/api/third-resource") && Method("GET") && HostAny("feature-employee-access.example.org", "feature-employee-access.example.org:443") && Header("X-Forwarded-Proto", "https") && Weight(4) && JWTPayloadAllKV("https://identity.zalando.com/realm", "users")
+fg_eaccess_default_feature_employee_access_feature_employee_access_example_org__api_third_resource_get: Path("/api/third-resource") && Method("GET") && HostAny("feature-employee-access.example.org", "feature-employee-access.example.org:443") && Header("X-Forwarded-Proto", "https") && Weight(4) && JWTPayloadAnyKV("https://identity.zalando.com/realm", "users")
 	-> status(403)
 	-> inlineContent("{\"title\":\"Gateway Rejected\",\"status\":403,\"detail\":\"deny all employees\"}")
 	-> <shunt>;

--- a/fabric/testdata/feature/feature-svc-whitelist-with-admin.eskip
+++ b/fabric/testdata/feature/feature-svc-whitelist-with-admin.eskip
@@ -38,7 +38,7 @@ fg_default_feature_service_whitelist_feature_service_whitelist_example_org__api_
 	-> forwardToken("X-TokenInfo-Forward", "uid", "scope", "realm")
 	-> <roundRobin, "http://10.2.23.42:8080", "http://10.2.5.4:8080">;
 
-fg_admin_default_feature_service_whitelist_feature_service_whitelist_example_org__api_resource__get: Path("/api/resource") && Method("GET") && HostAny("feature-service-whitelist.example.org", "feature-service-whitelist.example.org:443") && Header("X-Forwarded-Proto", "https") && Weight(5) && JWTPayloadAllKV("https://identity.zalando.com/realm", "users") && JWTPayloadAnyKV("https://identity.zalando.com/managed-id", "jblogs")
+fg_admin_default_feature_service_whitelist_feature_service_whitelist_example_org__api_resource__get: Path("/api/resource") && Method("GET") && HostAny("feature-service-whitelist.example.org", "feature-service-whitelist.example.org:443") && Header("X-Forwarded-Proto", "https") && Weight(5) && JWTPayloadAnyKV("https://identity.zalando.com/realm", "users") && JWTPayloadAnyKV("https://identity.zalando.com/managed-id", "jblogs")
 	-> oauthTokeninfoAnyKV("realm", "/services", "realm", "/employees")
 	-> enableAccessLog(2, 4, 5)
 	-> oauthTokeninfoAllScope("uid")
@@ -47,7 +47,7 @@ fg_admin_default_feature_service_whitelist_feature_service_whitelist_example_org
 	-> forwardToken("X-TokenInfo-Forward", "uid", "scope", "realm")
 	-> <roundRobin, "http://10.2.23.42:8080", "http://10.2.5.4:8080">;
 
-fg_admin_default_feature_service_whitelist_feature_service_whitelist_example_org__api_resource__head: Path("/api/resource") && Method("HEAD") && HostAny("feature-service-whitelist.example.org", "feature-service-whitelist.example.org:443") && Header("X-Forwarded-Proto", "https") && Weight(5) && JWTPayloadAllKV("https://identity.zalando.com/realm", "users") && JWTPayloadAnyKV("https://identity.zalando.com/managed-id", "jblogs")
+fg_admin_default_feature_service_whitelist_feature_service_whitelist_example_org__api_resource__head: Path("/api/resource") && Method("HEAD") && HostAny("feature-service-whitelist.example.org", "feature-service-whitelist.example.org:443") && Header("X-Forwarded-Proto", "https") && Weight(5) && JWTPayloadAnyKV("https://identity.zalando.com/realm", "users") && JWTPayloadAnyKV("https://identity.zalando.com/managed-id", "jblogs")
 	-> oauthTokeninfoAnyKV("realm", "/services", "realm", "/employees")
 	-> enableAccessLog(2, 4, 5)
 	-> oauthTokeninfoAllScope("uid")
@@ -56,7 +56,7 @@ fg_admin_default_feature_service_whitelist_feature_service_whitelist_example_org
 	-> forwardToken("X-TokenInfo-Forward", "uid", "scope", "realm")
 	-> <roundRobin, "http://10.2.23.42:8080", "http://10.2.5.4:8080">;
 
-fg_admin_default_feature_service_whitelist_feature_service_whitelist_example_org__api_resource__post: Path("/api/resource") && Method("POST") && HostAny("feature-service-whitelist.example.org", "feature-service-whitelist.example.org:443") && Header("X-Forwarded-Proto", "https") && Weight(5) && JWTPayloadAllKV("https://identity.zalando.com/realm", "users") && JWTPayloadAnyKV("https://identity.zalando.com/managed-id", "jblogs")
+fg_admin_default_feature_service_whitelist_feature_service_whitelist_example_org__api_resource__post: Path("/api/resource") && Method("POST") && HostAny("feature-service-whitelist.example.org", "feature-service-whitelist.example.org:443") && Header("X-Forwarded-Proto", "https") && Weight(5) && JWTPayloadAnyKV("https://identity.zalando.com/realm", "users") && JWTPayloadAnyKV("https://identity.zalando.com/managed-id", "jblogs")
 	-> oauthTokeninfoAnyKV("realm", "/services", "realm", "/employees")
 	-> enableAccessLog(2, 4, 5)
 	-> oauthTokeninfoAllScope("uid")
@@ -65,7 +65,7 @@ fg_admin_default_feature_service_whitelist_feature_service_whitelist_example_org
 	-> forwardToken("X-TokenInfo-Forward", "uid", "scope", "realm")
 	-> <roundRobin, "http://10.2.23.42:8080", "http://10.2.5.4:8080">;
 
-fg_admin_default_feature_service_whitelist_feature_service_whitelist_example_org__api_resource__resource_id___put: Path("/api/resource/:resource_id") && Method("PUT") && HostAny("feature-service-whitelist.example.org", "feature-service-whitelist.example.org:443") && Header("X-Forwarded-Proto", "https") && Weight(5) && JWTPayloadAllKV("https://identity.zalando.com/realm", "users") && JWTPayloadAnyKV("https://identity.zalando.com/managed-id", "jblogs")
+fg_admin_default_feature_service_whitelist_feature_service_whitelist_example_org__api_resource__resource_id___put: Path("/api/resource/:resource_id") && Method("PUT") && HostAny("feature-service-whitelist.example.org", "feature-service-whitelist.example.org:443") && Header("X-Forwarded-Proto", "https") && Weight(5) && JWTPayloadAnyKV("https://identity.zalando.com/realm", "users") && JWTPayloadAnyKV("https://identity.zalando.com/managed-id", "jblogs")
 	-> oauthTokeninfoAnyKV("realm", "/services", "realm", "/employees")
 	-> enableAccessLog(2, 4, 5)
 	-> oauthTokeninfoAllScope("uid")

--- a/fabric/testdata/feature/multi-path-single-method-single-admin.eskip
+++ b/fabric/testdata/feature/multi-path-single-method-single-admin.eskip
@@ -5,7 +5,7 @@ fg_404_default_simplest_multi_path_simplest_multi_path_example_org__: HostAny("s
   -> inlineContent("{\"title\":\"Gateway Rejected\",\"status\":404,\"detail\":\"Gateway Route Not Matched\"}")
   -> <shunt>;
 
-fg_admin_default_simplest_multi_path_simplest_multi_path_example_org__resources__get: Path("/resources") && HostAny("simplest-multi-path.example.org", "simplest-multi-path.example.org:443") && Method("GET") && Header("X-Forwarded-Proto", "https") && Weight(5) && JWTPayloadAllKV("https://identity.zalando.com/realm", "users") && JWTPayloadAnyKV("https://identity.zalando.com/managed-id", "bmooney")
+fg_admin_default_simplest_multi_path_simplest_multi_path_example_org__resources__get: Path("/resources") && HostAny("simplest-multi-path.example.org", "simplest-multi-path.example.org:443") && Method("GET") && Header("X-Forwarded-Proto", "https") && Weight(5) && JWTPayloadAnyKV("https://identity.zalando.com/realm", "users") && JWTPayloadAnyKV("https://identity.zalando.com/managed-id", "bmooney")
   -> oauthTokeninfoAnyKV("realm", "/services", "realm", "/employees")
   -> enableAccessLog(2, 4, 5)
   -> oauthTokeninfoAllScope("uid")
@@ -15,7 +15,7 @@ fg_admin_default_simplest_multi_path_simplest_multi_path_example_org__resources_
   -> <roundRobin, "http://10.2.23.42:8080", "http://10.2.5.4:8080">;
 
 fg_admin_default_simplest_multi_path_simplest_multi_path_example_org__resources_sub__get:
-Path("/resources/sub") && HostAny("simplest-multi-path.example.org", "simplest-multi-path.example.org:443") && Method("GET") && Header("X-Forwarded-Proto", "https") && Weight(5) && JWTPayloadAllKV("https://identity.zalando.com/realm", "users") && JWTPayloadAnyKV("https://identity.zalando.com/managed-id", "bmooney")
+Path("/resources/sub") && HostAny("simplest-multi-path.example.org", "simplest-multi-path.example.org:443") && Method("GET") && Header("X-Forwarded-Proto", "https") && Weight(5) && JWTPayloadAnyKV("https://identity.zalando.com/realm", "users") && JWTPayloadAnyKV("https://identity.zalando.com/managed-id", "bmooney")
   -> oauthTokeninfoAnyKV("realm", "/services", "realm", "/employees")
   -> enableAccessLog(2, 4, 5)
   -> oauthTokeninfoAllScope("uid")

--- a/fabric/testdata/feature/multi-path-with-multi-overwrite-ratelimit-single-method-single-admin.eskip
+++ b/fabric/testdata/feature/multi-path-with-multi-overwrite-ratelimit-single-method-single-admin.eskip
@@ -5,7 +5,7 @@ fg_404_default_simplest_multi_path_with_multi_overwrite_ratelimit_simplest_multi
   -> inlineContent("{\"title\":\"Gateway Rejected\",\"status\":404,\"detail\":\"Gateway Route Not Matched\"}")
   -> <shunt>;
 
-fg_admin_default_simplest_multi_path_with_multi_overwrite_ratelimit_simplest_multi_path_with_multi_overwrite_ratelimit_example_org__resources__get: Path("/resources") && HostAny("simplest-multi-path-with-multi-overwrite-ratelimit.example.org", "simplest-multi-path-with-multi-overwrite-ratelimit.example.org:443") && Method("GET") && Header("X-Forwarded-Proto", "https") && Weight(5) && JWTPayloadAllKV("https://identity.zalando.com/realm", "users") && JWTPayloadAnyKV("https://identity.zalando.com/managed-id", "bmooney")
+fg_admin_default_simplest_multi_path_with_multi_overwrite_ratelimit_simplest_multi_path_with_multi_overwrite_ratelimit_example_org__resources__get: Path("/resources") && HostAny("simplest-multi-path-with-multi-overwrite-ratelimit.example.org", "simplest-multi-path-with-multi-overwrite-ratelimit.example.org:443") && Method("GET") && Header("X-Forwarded-Proto", "https") && Weight(5) && JWTPayloadAnyKV("https://identity.zalando.com/realm", "users") && JWTPayloadAnyKV("https://identity.zalando.com/managed-id", "bmooney")
   -> oauthTokeninfoAnyKV("realm", "/services", "realm", "/employees")
   -> enableAccessLog(2, 4, 5)
   -> oauthTokeninfoAllScope("uid")
@@ -15,7 +15,7 @@ fg_admin_default_simplest_multi_path_with_multi_overwrite_ratelimit_simplest_mul
   -> <roundRobin, "http://10.2.23.42:8080", "http://10.2.5.4:8080">;
 
 fg_admin_default_simplest_multi_path_with_multi_overwrite_ratelimit_simplest_multi_path_with_multi_overwrite_ratelimit_example_org__resources_sub__get:
-Path("/resources/sub") && HostAny("simplest-multi-path-with-multi-overwrite-ratelimit.example.org", "simplest-multi-path-with-multi-overwrite-ratelimit.example.org:443") && Method("GET") && Header("X-Forwarded-Proto", "https") && Weight(5) && JWTPayloadAllKV("https://identity.zalando.com/realm", "users") && JWTPayloadAnyKV("https://identity.zalando.com/managed-id", "bmooney")
+Path("/resources/sub") && HostAny("simplest-multi-path-with-multi-overwrite-ratelimit.example.org", "simplest-multi-path-with-multi-overwrite-ratelimit.example.org:443") && Method("GET") && Header("X-Forwarded-Proto", "https") && Weight(5) && JWTPayloadAnyKV("https://identity.zalando.com/realm", "users") && JWTPayloadAnyKV("https://identity.zalando.com/managed-id", "bmooney")
   -> oauthTokeninfoAnyKV("realm", "/services", "realm", "/employees")
   -> enableAccessLog(2, 4, 5)
   -> oauthTokeninfoAllScope("uid")

--- a/fabric/testdata/feature/multi-path-with-ratelimit-single-method-single-admin.eskip
+++ b/fabric/testdata/feature/multi-path-with-ratelimit-single-method-single-admin.eskip
@@ -5,7 +5,7 @@ fg_404_default_simplest_multi_path_with_ratelimit_simplest_multi_path_with_ratel
   -> inlineContent("{\"title\":\"Gateway Rejected\",\"status\":404,\"detail\":\"Gateway Route Not Matched\"}")
   -> <shunt>;
 
-fg_admin_default_simplest_multi_path_with_ratelimit_simplest_multi_path_with_ratelimit_example_org__resources__get: Path("/resources") && HostAny("simplest-multi-path-with-ratelimit.example.org", "simplest-multi-path-with-ratelimit.example.org:443") && Method("GET") && Header("X-Forwarded-Proto", "https") && Weight(5) && JWTPayloadAllKV("https://identity.zalando.com/realm", "users") && JWTPayloadAnyKV("https://identity.zalando.com/managed-id", "bmooney")
+fg_admin_default_simplest_multi_path_with_ratelimit_simplest_multi_path_with_ratelimit_example_org__resources__get: Path("/resources") && HostAny("simplest-multi-path-with-ratelimit.example.org", "simplest-multi-path-with-ratelimit.example.org:443") && Method("GET") && Header("X-Forwarded-Proto", "https") && Weight(5) && JWTPayloadAnyKV("https://identity.zalando.com/realm", "users") && JWTPayloadAnyKV("https://identity.zalando.com/managed-id", "bmooney")
   -> oauthTokeninfoAnyKV("realm", "/services", "realm", "/employees")
   -> enableAccessLog(2, 4, 5)
   -> oauthTokeninfoAllScope("uid")
@@ -15,7 +15,7 @@ fg_admin_default_simplest_multi_path_with_ratelimit_simplest_multi_path_with_rat
   -> <roundRobin, "http://10.2.23.42:8080", "http://10.2.5.4:8080">;
 
 fg_admin_default_simplest_multi_path_with_ratelimit_simplest_multi_path_with_ratelimit_example_org__resources_sub__get:
-Path("/resources/sub") && HostAny("simplest-multi-path-with-ratelimit.example.org", "simplest-multi-path-with-ratelimit.example.org:443") && Method("GET") && Header("X-Forwarded-Proto", "https") && Weight(5) && JWTPayloadAllKV("https://identity.zalando.com/realm", "users") && JWTPayloadAnyKV("https://identity.zalando.com/managed-id", "bmooney")
+Path("/resources/sub") && HostAny("simplest-multi-path-with-ratelimit.example.org", "simplest-multi-path-with-ratelimit.example.org:443") && Method("GET") && Header("X-Forwarded-Proto", "https") && Weight(5) && JWTPayloadAnyKV("https://identity.zalando.com/realm", "users") && JWTPayloadAnyKV("https://identity.zalando.com/managed-id", "bmooney")
   -> oauthTokeninfoAnyKV("realm", "/services", "realm", "/employees")
   -> enableAccessLog(2, 4, 5)
   -> oauthTokeninfoAllScope("uid")

--- a/fabric/testdata/feature/single-path-multi-method-single-admin-different-authnz.eskip
+++ b/fabric/testdata/feature/single-path-multi-method-single-admin-different-authnz.eskip
@@ -5,7 +5,7 @@ fg_404_default_simplest_multi_method_diff_authnz_simplest_multi_method_diff_auth
   -> inlineContent("{\"title\":\"Gateway Rejected\",\"status\":404,\"detail\":\"Gateway Route Not Matched\"}")
   -> <shunt>;
 
-fg_admin_default_simplest_multi_method_diff_authnz_simplest_multi_method_diff_authnz_example_org__resources__get: Path("/resources") && HostAny("simplest-multi-method-diff-authnz.example.org", "simplest-multi-method-diff-authnz.example.org:443") && Method("GET") && Header("X-Forwarded-Proto", "https") && Weight(5) && JWTPayloadAllKV("https://identity.zalando.com/realm", "users") && JWTPayloadAnyKV("https://identity.zalando.com/managed-id", "bmooney")
+fg_admin_default_simplest_multi_method_diff_authnz_simplest_multi_method_diff_authnz_example_org__resources__get: Path("/resources") && HostAny("simplest-multi-method-diff-authnz.example.org", "simplest-multi-method-diff-authnz.example.org:443") && Method("GET") && Header("X-Forwarded-Proto", "https") && Weight(5) && JWTPayloadAnyKV("https://identity.zalando.com/realm", "users") && JWTPayloadAnyKV("https://identity.zalando.com/managed-id", "bmooney")
   -> oauthTokeninfoAnyKV("realm", "/services", "realm", "/employees")
   -> enableAccessLog(2, 4, 5)
   -> oauthTokeninfoAllScope("uid")
@@ -14,7 +14,7 @@ fg_admin_default_simplest_multi_method_diff_authnz_simplest_multi_method_diff_au
   -> forwardToken("X-TokenInfo-Forward", "uid", "scope", "realm")
   -> <roundRobin, "http://10.2.23.42:8080", "http://10.2.5.4:8080">;
 
-fg_admin_default_simplest_multi_method_diff_authnz_simplest_multi_method_diff_authnz_example_org__resources__put: Path("/resources") && HostAny("simplest-multi-method-diff-authnz.example.org", "simplest-multi-method-diff-authnz.example.org:443") && Method("PUT") && Header("X-Forwarded-Proto", "https") && Weight(5) && JWTPayloadAllKV("https://identity.zalando.com/realm", "users") && JWTPayloadAnyKV("https://identity.zalando.com/managed-id", "bmooney")
+fg_admin_default_simplest_multi_method_diff_authnz_simplest_multi_method_diff_authnz_example_org__resources__put: Path("/resources") && HostAny("simplest-multi-method-diff-authnz.example.org", "simplest-multi-method-diff-authnz.example.org:443") && Method("PUT") && Header("X-Forwarded-Proto", "https") && Weight(5) && JWTPayloadAnyKV("https://identity.zalando.com/realm", "users") && JWTPayloadAnyKV("https://identity.zalando.com/managed-id", "bmooney")
   -> oauthTokeninfoAnyKV("realm", "/services", "realm", "/employees")
   -> enableAccessLog(2, 4, 5)
   -> oauthTokeninfoAllScope("uid")

--- a/fabric/testdata/feature/single-path-multi-method-single-admin-multi-scope-authnz.eskip
+++ b/fabric/testdata/feature/single-path-multi-method-single-admin-multi-scope-authnz.eskip
@@ -5,7 +5,7 @@ fg_404_default_simplest_multi_app_authnz_simplest_multi_app_authnz_example_org__
   -> inlineContent("{\"title\":\"Gateway Rejected\",\"status\":404,\"detail\":\"Gateway Route Not Matched\"}")
   -> <shunt>;
 
-fg_admin_default_simplest_multi_app_authnz_simplest_multi_app_authnz_example_org__resources__get: Path("/resources") && HostAny("simplest-multi-app-authnz.example.org", "simplest-multi-app-authnz.example.org:443") && Method("GET") && Header("X-Forwarded-Proto", "https") && Weight(5) && JWTPayloadAllKV("https://identity.zalando.com/realm", "users") && JWTPayloadAnyKV("https://identity.zalando.com/managed-id", "bmooney")
+fg_admin_default_simplest_multi_app_authnz_simplest_multi_app_authnz_example_org__resources__get: Path("/resources") && HostAny("simplest-multi-app-authnz.example.org", "simplest-multi-app-authnz.example.org:443") && Method("GET") && Header("X-Forwarded-Proto", "https") && Weight(5) && JWTPayloadAnyKV("https://identity.zalando.com/realm", "users") && JWTPayloadAnyKV("https://identity.zalando.com/managed-id", "bmooney")
   -> oauthTokeninfoAnyKV("realm", "/services", "realm", "/employees")
   -> enableAccessLog(2, 4, 5)
   -> oauthTokeninfoAllScope("uid")
@@ -14,7 +14,7 @@ fg_admin_default_simplest_multi_app_authnz_simplest_multi_app_authnz_example_org
   -> forwardToken("X-TokenInfo-Forward", "uid", "scope", "realm")
   -> <roundRobin, "http://10.2.23.42:8080", "http://10.2.5.4:8080">;
 
-fg_admin_default_simplest_multi_app_authnz_simplest_multi_app_authnz_example_org__resources__put: Path("/resources") && HostAny("simplest-multi-app-authnz.example.org", "simplest-multi-app-authnz.example.org:443") && Method("PUT") && Header("X-Forwarded-Proto", "https") && Weight(5) && JWTPayloadAllKV("https://identity.zalando.com/realm", "users") && JWTPayloadAnyKV("https://identity.zalando.com/managed-id", "bmooney")
+fg_admin_default_simplest_multi_app_authnz_simplest_multi_app_authnz_example_org__resources__put: Path("/resources") && HostAny("simplest-multi-app-authnz.example.org", "simplest-multi-app-authnz.example.org:443") && Method("PUT") && Header("X-Forwarded-Proto", "https") && Weight(5) && JWTPayloadAnyKV("https://identity.zalando.com/realm", "users") && JWTPayloadAnyKV("https://identity.zalando.com/managed-id", "bmooney")
   -> oauthTokeninfoAnyKV("realm", "/services", "realm", "/employees")
   -> enableAccessLog(2, 4, 5)
   -> oauthTokeninfoAllScope("uid")

--- a/fabric/testdata/feature/single-path-multi-method-single-admin.eskip
+++ b/fabric/testdata/feature/single-path-multi-method-single-admin.eskip
@@ -5,7 +5,7 @@ fg_404_default_simplest_multi_method_simplest_multi_method_example_org__: HostAn
   -> inlineContent("{\"title\":\"Gateway Rejected\",\"status\":404,\"detail\":\"Gateway Route Not Matched\"}")
   -> <shunt>;
 
-fg_admin_default_simplest_multi_method_simplest_multi_method_example_org__resources__get: Path("/resources") && HostAny("simplest-multi-method.example.org", "simplest-multi-method.example.org:443") && Method("GET") && Header("X-Forwarded-Proto", "https") && Weight(5) && JWTPayloadAllKV("https://identity.zalando.com/realm", "users") && JWTPayloadAnyKV("https://identity.zalando.com/managed-id", "bmooney")
+fg_admin_default_simplest_multi_method_simplest_multi_method_example_org__resources__get: Path("/resources") && HostAny("simplest-multi-method.example.org", "simplest-multi-method.example.org:443") && Method("GET") && Header("X-Forwarded-Proto", "https") && Weight(5) && JWTPayloadAnyKV("https://identity.zalando.com/realm", "users") && JWTPayloadAnyKV("https://identity.zalando.com/managed-id", "bmooney")
   -> oauthTokeninfoAnyKV("realm", "/services", "realm", "/employees")
   -> enableAccessLog(2, 4, 5)
   -> oauthTokeninfoAllScope("uid")
@@ -14,7 +14,7 @@ fg_admin_default_simplest_multi_method_simplest_multi_method_example_org__resour
   -> forwardToken("X-TokenInfo-Forward", "uid", "scope", "realm")
   -> <roundRobin, "http://10.2.23.42:8080", "http://10.2.5.4:8080">;
 
-fg_admin_default_simplest_multi_method_simplest_multi_method_example_org__resources__put: Path("/resources") && HostAny("simplest-multi-method.example.org", "simplest-multi-method.example.org:443") && Method("PUT") && Header("X-Forwarded-Proto", "https") && Weight(5) && JWTPayloadAllKV("https://identity.zalando.com/realm", "users") && JWTPayloadAnyKV("https://identity.zalando.com/managed-id", "bmooney")
+fg_admin_default_simplest_multi_method_simplest_multi_method_example_org__resources__put: Path("/resources") && HostAny("simplest-multi-method.example.org", "simplest-multi-method.example.org:443") && Method("PUT") && Header("X-Forwarded-Proto", "https") && Weight(5) && JWTPayloadAnyKV("https://identity.zalando.com/realm", "users") && JWTPayloadAnyKV("https://identity.zalando.com/managed-id", "bmooney")
   -> oauthTokeninfoAnyKV("realm", "/services", "realm", "/employees")
   -> enableAccessLog(2, 4, 5)
   -> oauthTokeninfoAllScope("uid")

--- a/fabric/testdata/feature/single-path-single-method-multi-admin.eskip
+++ b/fabric/testdata/feature/single-path-single-method-multi-admin.eskip
@@ -5,7 +5,7 @@ fg_404_default_simplest_multi_admin_simplest_multi_admin_example_org__: HostAny(
   -> inlineContent("{\"title\":\"Gateway Rejected\",\"status\":404,\"detail\":\"Gateway Route Not Matched\"}")
   -> <shunt>;
 
-fg_admin_default_simplest_multi_admin_simplest_multi_admin_example_org__resources__get: Path("/resources") && HostAny("simplest-multi-admin.example.org", "simplest-multi-admin.example.org:443") && Method("GET") && Header("X-Forwarded-Proto", "https") && Weight(5) && JWTPayloadAllKV("https://identity.zalando.com/realm", "users") && JWTPayloadAnyKV("https://identity.zalando.com/managed-id", "bmooney", "https://identity.zalando.com/managed-id", "szuecs")
+fg_admin_default_simplest_multi_admin_simplest_multi_admin_example_org__resources__get: Path("/resources") && HostAny("simplest-multi-admin.example.org", "simplest-multi-admin.example.org:443") && Method("GET") && Header("X-Forwarded-Proto", "https") && Weight(5) && JWTPayloadAnyKV("https://identity.zalando.com/realm", "users") && JWTPayloadAnyKV("https://identity.zalando.com/managed-id", "bmooney", "https://identity.zalando.com/managed-id", "szuecs")
   -> oauthTokeninfoAnyKV("realm", "/services", "realm", "/employees")
   -> enableAccessLog(2, 4, 5)
   -> oauthTokeninfoAllScope("uid")

--- a/fabric/testdata/feature/single-path-single-method-single-admin-single-cors.eskip
+++ b/fabric/testdata/feature/single-path-single-method-single-admin-single-cors.eskip
@@ -5,7 +5,7 @@ fg_404_default_simplest_with_cors_simplest_example_org__: HostAny("simplest.exam
   -> inlineContent("{\"title\":\"Gateway Rejected\",\"status\":404,\"detail\":\"Gateway Route Not Matched\"}")
   -> <shunt>;
 
-fg_admin_default_simplest_with_cors_simplest_example_org__resources__get: Path("/resources") && HostAny("simplest.example.org", "simplest.example.org:443") && Method("GET") && Header("X-Forwarded-Proto", "https") && Weight(5) && JWTPayloadAllKV("https://identity.zalando.com/realm", "users") && JWTPayloadAnyKV("https://identity.zalando.com/managed-id", "bmooney")
+fg_admin_default_simplest_with_cors_simplest_example_org__resources__get: Path("/resources") && HostAny("simplest.example.org", "simplest.example.org:443") && Method("GET") && Header("X-Forwarded-Proto", "https") && Weight(5) && JWTPayloadAnyKV("https://identity.zalando.com/realm", "users") && JWTPayloadAnyKV("https://identity.zalando.com/managed-id", "bmooney")
   -> oauthTokeninfoAnyKV("realm", "/services", "realm", "/employees")
   -> enableAccessLog(2, 4, 5)
   -> oauthTokeninfoAllScope("uid")

--- a/fabric/testdata/feature/single-path-single-method-single-admin.eskip
+++ b/fabric/testdata/feature/single-path-single-method-single-admin.eskip
@@ -5,7 +5,7 @@ fg_404_default_simplest_simplest_example_org__: HostAny("simplest.example.org", 
   -> inlineContent("{\"title\":\"Gateway Rejected\",\"status\":404,\"detail\":\"Gateway Route Not Matched\"}")
   -> <shunt>;
 
-fg_admin_default_simplest_simplest_example_org__resources__get: Path("/resources") && HostAny("simplest.example.org", "simplest.example.org:443") && Method("GET") && Header("X-Forwarded-Proto", "https") && Weight(5) && JWTPayloadAllKV("https://identity.zalando.com/realm", "users") && JWTPayloadAnyKV("https://identity.zalando.com/managed-id", "bmooney")
+fg_admin_default_simplest_simplest_example_org__resources__get: Path("/resources") && HostAny("simplest.example.org", "simplest.example.org:443") && Method("GET") && Header("X-Forwarded-Proto", "https") && Weight(5) && JWTPayloadAnyKV("https://identity.zalando.com/realm", "users") && JWTPayloadAnyKV("https://identity.zalando.com/managed-id", "bmooney")
   -> oauthTokeninfoAnyKV("realm", "/services", "realm", "/employees")
   -> enableAccessLog(2, 4, 5)
   -> oauthTokeninfoAllScope("uid")

--- a/fabric/testdata/feature/traffic-switching-complex.eskip
+++ b/fabric/testdata/feature/traffic-switching-complex.eskip
@@ -20,7 +20,7 @@ fg_traffic_3_traffic_switching_stackset_managed_test_cluster_zalan_do__resources
 	-> forwardToken("X-TokenInfo-Forward", "uid", "scope", "realm")
 	-> <roundRobin, "http://10.2.100.10:8088", "http://10.2.100.11:8088", "http://10.2.100.12:8088">;
 
-fg_admin_traffic_3_traffic_switching_stackset_managed_test_cluster_zalan_do__resources__0_get: Path("/resources") && Method("GET") && HostAny("stackset-managed-test.cluster.zalan.do", "stackset-managed-test.cluster.zalan.do:443") && Header("X-Forwarded-Proto", "https") && Weight(5) && JWTPayloadAllKV("https://identity.zalando.com/realm", "users") && JWTPayloadAnyKV("https://identity.zalando.com/managed-id", "bmooney") && Traffic(0.3333333333333333) && True()
+fg_admin_traffic_3_traffic_switching_stackset_managed_test_cluster_zalan_do__resources__0_get: Path("/resources") && Method("GET") && HostAny("stackset-managed-test.cluster.zalan.do", "stackset-managed-test.cluster.zalan.do:443") && Header("X-Forwarded-Proto", "https") && Weight(5) && JWTPayloadAnyKV("https://identity.zalando.com/realm", "users") && JWTPayloadAnyKV("https://identity.zalando.com/managed-id", "bmooney") && Traffic(0.3333333333333333) && True()
 	-> oauthTokeninfoAnyKV("realm", "/services", "realm", "/employees")
 	-> enableAccessLog(2, 4, 5)
 	-> oauthTokeninfoAllScope("uid")
@@ -37,7 +37,7 @@ fg_traffic_3_traffic_switching_stackset_managed_test_cluster_zalan_do__resources
 	-> forwardToken("X-TokenInfo-Forward", "uid", "scope", "realm")
 	-> <roundRobin, "http://10.2.100.10:8088", "http://10.2.100.11:8088", "http://10.2.100.12:8088">;
 
-fg_admin_traffic_3_traffic_switching_stackset_managed_test_cluster_zalan_do__resources__0_post: Path("/resources") && Method("POST") && HostAny("stackset-managed-test.cluster.zalan.do", "stackset-managed-test.cluster.zalan.do:443") && Header("X-Forwarded-Proto", "https") && Weight(5) && JWTPayloadAllKV("https://identity.zalando.com/realm", "users") && JWTPayloadAnyKV("https://identity.zalando.com/managed-id", "bmooney") && Traffic(0.3333333333333333) && True()
+fg_admin_traffic_3_traffic_switching_stackset_managed_test_cluster_zalan_do__resources__0_post: Path("/resources") && Method("POST") && HostAny("stackset-managed-test.cluster.zalan.do", "stackset-managed-test.cluster.zalan.do:443") && Header("X-Forwarded-Proto", "https") && Weight(5) && JWTPayloadAnyKV("https://identity.zalando.com/realm", "users") && JWTPayloadAnyKV("https://identity.zalando.com/managed-id", "bmooney") && Traffic(0.3333333333333333) && True()
 	-> oauthTokeninfoAnyKV("realm", "/services", "realm", "/employees")
 	-> enableAccessLog(2, 4, 5)
 	-> oauthTokeninfoAllScope("uid")
@@ -54,7 +54,7 @@ fg_traffic_3_traffic_switching_stackset_managed_test_cluster_zalan_do__resources
 	-> forwardToken("X-TokenInfo-Forward", "uid", "scope", "realm")
 	-> <roundRobin, "http://10.2.100.10:8088", "http://10.2.100.11:8088", "http://10.2.100.12:8088">;
 
-fg_admin_traffic_3_traffic_switching_stackset_managed_test_cluster_zalan_do__resources_sub__0_get: Path("/resources/sub") && Method("GET") && HostAny("stackset-managed-test.cluster.zalan.do", "stackset-managed-test.cluster.zalan.do:443") && Header("X-Forwarded-Proto", "https") && Weight(5) && JWTPayloadAllKV("https://identity.zalando.com/realm", "users") && JWTPayloadAnyKV("https://identity.zalando.com/managed-id", "bmooney") && Traffic(0.3333333333333333) && True()
+fg_admin_traffic_3_traffic_switching_stackset_managed_test_cluster_zalan_do__resources_sub__0_get: Path("/resources/sub") && Method("GET") && HostAny("stackset-managed-test.cluster.zalan.do", "stackset-managed-test.cluster.zalan.do:443") && Header("X-Forwarded-Proto", "https") && Weight(5) && JWTPayloadAnyKV("https://identity.zalando.com/realm", "users") && JWTPayloadAnyKV("https://identity.zalando.com/managed-id", "bmooney") && Traffic(0.3333333333333333) && True()
 	-> oauthTokeninfoAnyKV("realm", "/services", "realm", "/employees")
 	-> enableAccessLog(2, 4, 5)
 	-> oauthTokeninfoAllScope("uid")
@@ -78,7 +78,7 @@ fg_traffic_3_traffic_switching_stackset_managed_test_ingress_cluster_local__reso
 	-> forwardToken("X-TokenInfo-Forward", "uid", "scope", "realm")
 	-> <roundRobin, "http://10.2.100.10:8088", "http://10.2.100.11:8088", "http://10.2.100.12:8088">;
 
-fg_admin_traffic_3_traffic_switching_stackset_managed_test_ingress_cluster_local__resources__0_get: Path("/resources") && Method("GET") && HostAny("stackset-managed-test.ingress.cluster.local", "stackset-managed-test.ingress.cluster.local:80") && Weight(5) && JWTPayloadAllKV("https://identity.zalando.com/realm", "users") && JWTPayloadAnyKV("https://identity.zalando.com/managed-id", "bmooney") && Traffic(0.3333333333333333) && True()
+fg_admin_traffic_3_traffic_switching_stackset_managed_test_ingress_cluster_local__resources__0_get: Path("/resources") && Method("GET") && HostAny("stackset-managed-test.ingress.cluster.local", "stackset-managed-test.ingress.cluster.local:80") && Weight(5) && JWTPayloadAnyKV("https://identity.zalando.com/realm", "users") && JWTPayloadAnyKV("https://identity.zalando.com/managed-id", "bmooney") && Traffic(0.3333333333333333) && True()
 	-> oauthTokeninfoAnyKV("realm", "/services", "realm", "/employees")
 	-> enableAccessLog(2, 4, 5)
 	-> oauthTokeninfoAllScope("uid")
@@ -95,7 +95,7 @@ fg_traffic_3_traffic_switching_stackset_managed_test_ingress_cluster_local__reso
 	-> forwardToken("X-TokenInfo-Forward", "uid", "scope", "realm")
 	-> <roundRobin, "http://10.2.100.10:8088", "http://10.2.100.11:8088", "http://10.2.100.12:8088">;
 
-fg_admin_traffic_3_traffic_switching_stackset_managed_test_ingress_cluster_local__resources__0_post: Path("/resources") && Method("POST") && HostAny("stackset-managed-test.ingress.cluster.local", "stackset-managed-test.ingress.cluster.local:80") && Weight(5) && JWTPayloadAllKV("https://identity.zalando.com/realm", "users") && JWTPayloadAnyKV("https://identity.zalando.com/managed-id", "bmooney") && Traffic(0.3333333333333333) && True()
+fg_admin_traffic_3_traffic_switching_stackset_managed_test_ingress_cluster_local__resources__0_post: Path("/resources") && Method("POST") && HostAny("stackset-managed-test.ingress.cluster.local", "stackset-managed-test.ingress.cluster.local:80") && Weight(5) && JWTPayloadAnyKV("https://identity.zalando.com/realm", "users") && JWTPayloadAnyKV("https://identity.zalando.com/managed-id", "bmooney") && Traffic(0.3333333333333333) && True()
 	-> oauthTokeninfoAnyKV("realm", "/services", "realm", "/employees")
 	-> enableAccessLog(2, 4, 5)
 	-> oauthTokeninfoAllScope("uid")
@@ -112,7 +112,7 @@ fg_traffic_3_traffic_switching_stackset_managed_test_ingress_cluster_local__reso
 	-> forwardToken("X-TokenInfo-Forward", "uid", "scope", "realm")
 	-> <roundRobin, "http://10.2.100.10:8088", "http://10.2.100.11:8088", "http://10.2.100.12:8088">;
 
-fg_admin_traffic_3_traffic_switching_stackset_managed_test_ingress_cluster_local__resources_sub__0_get: Path("/resources/sub") && Method("GET") && HostAny("stackset-managed-test.ingress.cluster.local", "stackset-managed-test.ingress.cluster.local:80") && Weight(5) && JWTPayloadAllKV("https://identity.zalando.com/realm", "users") && JWTPayloadAnyKV("https://identity.zalando.com/managed-id", "bmooney") && Traffic(0.3333333333333333) && True()
+fg_admin_traffic_3_traffic_switching_stackset_managed_test_ingress_cluster_local__resources_sub__0_get: Path("/resources/sub") && Method("GET") && HostAny("stackset-managed-test.ingress.cluster.local", "stackset-managed-test.ingress.cluster.local:80") && Weight(5) && JWTPayloadAnyKV("https://identity.zalando.com/realm", "users") && JWTPayloadAnyKV("https://identity.zalando.com/managed-id", "bmooney") && Traffic(0.3333333333333333) && True()
 	-> oauthTokeninfoAnyKV("realm", "/services", "realm", "/employees")
 	-> enableAccessLog(2, 4, 5)
 	-> oauthTokeninfoAllScope("uid")
@@ -129,7 +129,7 @@ fg_traffic_3_traffic_switching_stackset_managed_test_cluster_zalan_do__resources
 	-> forwardToken("X-TokenInfo-Forward", "uid", "scope", "realm")
 	-> <roundRobin, "http://10.2.100.10:8088", "http://10.2.100.11:8088", "http://10.2.100.12:8088">;
 
-fg_admin_traffic_3_traffic_switching_stackset_managed_test_cluster_zalan_do__resources__1_get: Path("/resources") && Method("GET") && HostAny("stackset-managed-test.cluster.zalan.do", "stackset-managed-test.cluster.zalan.do:443") && Header("X-Forwarded-Proto", "https") && Weight(5) && JWTPayloadAllKV("https://identity.zalando.com/realm", "users") && JWTPayloadAnyKV("https://identity.zalando.com/managed-id", "bmooney") && Traffic(0.5)
+fg_admin_traffic_3_traffic_switching_stackset_managed_test_cluster_zalan_do__resources__1_get: Path("/resources") && Method("GET") && HostAny("stackset-managed-test.cluster.zalan.do", "stackset-managed-test.cluster.zalan.do:443") && Header("X-Forwarded-Proto", "https") && Weight(5) && JWTPayloadAnyKV("https://identity.zalando.com/realm", "users") && JWTPayloadAnyKV("https://identity.zalando.com/managed-id", "bmooney") && Traffic(0.5)
 	-> oauthTokeninfoAnyKV("realm", "/services", "realm", "/employees")
 	-> enableAccessLog(2, 4, 5)
 	-> oauthTokeninfoAllScope("uid")
@@ -146,7 +146,7 @@ fg_traffic_3_traffic_switching_stackset_managed_test_cluster_zalan_do__resources
 	-> forwardToken("X-TokenInfo-Forward", "uid", "scope", "realm")
 	-> <roundRobin, "http://10.2.100.10:8088", "http://10.2.100.11:8088", "http://10.2.100.12:8088">;
 
-fg_admin_traffic_3_traffic_switching_stackset_managed_test_cluster_zalan_do__resources__1_post: Path("/resources") && Method("POST") && HostAny("stackset-managed-test.cluster.zalan.do", "stackset-managed-test.cluster.zalan.do:443") && Header("X-Forwarded-Proto", "https") && Weight(5) && JWTPayloadAllKV("https://identity.zalando.com/realm", "users") && JWTPayloadAnyKV("https://identity.zalando.com/managed-id", "bmooney") && Traffic(0.5)
+fg_admin_traffic_3_traffic_switching_stackset_managed_test_cluster_zalan_do__resources__1_post: Path("/resources") && Method("POST") && HostAny("stackset-managed-test.cluster.zalan.do", "stackset-managed-test.cluster.zalan.do:443") && Header("X-Forwarded-Proto", "https") && Weight(5) && JWTPayloadAnyKV("https://identity.zalando.com/realm", "users") && JWTPayloadAnyKV("https://identity.zalando.com/managed-id", "bmooney") && Traffic(0.5)
 	-> oauthTokeninfoAnyKV("realm", "/services", "realm", "/employees")
 	-> enableAccessLog(2, 4, 5)
 	-> oauthTokeninfoAllScope("uid")
@@ -163,7 +163,7 @@ fg_traffic_3_traffic_switching_stackset_managed_test_cluster_zalan_do__resources
 	-> forwardToken("X-TokenInfo-Forward", "uid", "scope", "realm")
 	-> <roundRobin, "http://10.2.100.10:8088", "http://10.2.100.11:8088", "http://10.2.100.12:8088">;
 
-fg_admin_traffic_3_traffic_switching_stackset_managed_test_cluster_zalan_do__resources_sub__1_get: Path("/resources/sub") && Method("GET") && HostAny("stackset-managed-test.cluster.zalan.do", "stackset-managed-test.cluster.zalan.do:443") && Header("X-Forwarded-Proto", "https") && Weight(5) && JWTPayloadAllKV("https://identity.zalando.com/realm", "users") && JWTPayloadAnyKV("https://identity.zalando.com/managed-id", "bmooney") && Traffic(0.5)
+fg_admin_traffic_3_traffic_switching_stackset_managed_test_cluster_zalan_do__resources_sub__1_get: Path("/resources/sub") && Method("GET") && HostAny("stackset-managed-test.cluster.zalan.do", "stackset-managed-test.cluster.zalan.do:443") && Header("X-Forwarded-Proto", "https") && Weight(5) && JWTPayloadAnyKV("https://identity.zalando.com/realm", "users") && JWTPayloadAnyKV("https://identity.zalando.com/managed-id", "bmooney") && Traffic(0.5)
 	-> oauthTokeninfoAnyKV("realm", "/services", "realm", "/employees")
 	-> enableAccessLog(2, 4, 5)
 	-> oauthTokeninfoAllScope("uid")
@@ -180,7 +180,7 @@ fg_traffic_3_traffic_switching_stackset_managed_test_ingress_cluster_local__reso
 	-> forwardToken("X-TokenInfo-Forward", "uid", "scope", "realm")
 	-> <roundRobin, "http://10.2.100.10:8088", "http://10.2.100.11:8088", "http://10.2.100.12:8088">;
 
-fg_admin_traffic_3_traffic_switching_stackset_managed_test_ingress_cluster_local__resources__1_get: Path("/resources") && Method("GET") && HostAny("stackset-managed-test.ingress.cluster.local", "stackset-managed-test.ingress.cluster.local:80") && Weight(5) && JWTPayloadAllKV("https://identity.zalando.com/realm", "users") && JWTPayloadAnyKV("https://identity.zalando.com/managed-id", "bmooney") && Traffic(0.5)
+fg_admin_traffic_3_traffic_switching_stackset_managed_test_ingress_cluster_local__resources__1_get: Path("/resources") && Method("GET") && HostAny("stackset-managed-test.ingress.cluster.local", "stackset-managed-test.ingress.cluster.local:80") && Weight(5) && JWTPayloadAnyKV("https://identity.zalando.com/realm", "users") && JWTPayloadAnyKV("https://identity.zalando.com/managed-id", "bmooney") && Traffic(0.5)
 	-> oauthTokeninfoAnyKV("realm", "/services", "realm", "/employees")
 	-> enableAccessLog(2, 4, 5)
 	-> oauthTokeninfoAllScope("uid")
@@ -197,7 +197,7 @@ fg_traffic_3_traffic_switching_stackset_managed_test_ingress_cluster_local__reso
 	-> forwardToken("X-TokenInfo-Forward", "uid", "scope", "realm")
 	-> <roundRobin, "http://10.2.100.10:8088", "http://10.2.100.11:8088", "http://10.2.100.12:8088">;
 
-fg_admin_traffic_3_traffic_switching_stackset_managed_test_ingress_cluster_local__resources__1_post: Path("/resources") && Method("POST") && HostAny("stackset-managed-test.ingress.cluster.local", "stackset-managed-test.ingress.cluster.local:80") && Weight(5) && JWTPayloadAllKV("https://identity.zalando.com/realm", "users") && JWTPayloadAnyKV("https://identity.zalando.com/managed-id", "bmooney") && Traffic(0.5)
+fg_admin_traffic_3_traffic_switching_stackset_managed_test_ingress_cluster_local__resources__1_post: Path("/resources") && Method("POST") && HostAny("stackset-managed-test.ingress.cluster.local", "stackset-managed-test.ingress.cluster.local:80") && Weight(5) && JWTPayloadAnyKV("https://identity.zalando.com/realm", "users") && JWTPayloadAnyKV("https://identity.zalando.com/managed-id", "bmooney") && Traffic(0.5)
 	-> oauthTokeninfoAnyKV("realm", "/services", "realm", "/employees")
 	-> enableAccessLog(2, 4, 5)
 	-> oauthTokeninfoAllScope("uid")
@@ -214,7 +214,7 @@ fg_traffic_3_traffic_switching_stackset_managed_test_ingress_cluster_local__reso
 	-> forwardToken("X-TokenInfo-Forward", "uid", "scope", "realm")
 	-> <roundRobin, "http://10.2.100.10:8088", "http://10.2.100.11:8088", "http://10.2.100.12:8088">;
 
-fg_admin_traffic_3_traffic_switching_stackset_managed_test_ingress_cluster_local__resources_sub__1_get: Path("/resources/sub") && Method("GET") && HostAny("stackset-managed-test.ingress.cluster.local", "stackset-managed-test.ingress.cluster.local:80") && Weight(5) && JWTPayloadAllKV("https://identity.zalando.com/realm", "users") && JWTPayloadAnyKV("https://identity.zalando.com/managed-id", "bmooney") && Traffic(0.5)
+fg_admin_traffic_3_traffic_switching_stackset_managed_test_ingress_cluster_local__resources_sub__1_get: Path("/resources/sub") && Method("GET") && HostAny("stackset-managed-test.ingress.cluster.local", "stackset-managed-test.ingress.cluster.local:80") && Weight(5) && JWTPayloadAnyKV("https://identity.zalando.com/realm", "users") && JWTPayloadAnyKV("https://identity.zalando.com/managed-id", "bmooney") && Traffic(0.5)
 	-> oauthTokeninfoAnyKV("realm", "/services", "realm", "/employees")
 	-> enableAccessLog(2, 4, 5)
 	-> oauthTokeninfoAllScope("uid")
@@ -231,7 +231,7 @@ fg_traffic_3_traffic_switching_stackset_managed_test_cluster_zalan_do__resources
 	-> forwardToken("X-TokenInfo-Forward", "uid", "scope", "realm")
 	-> <roundRobin, "http://10.2.100.10:8088", "http://10.2.100.11:8088", "http://10.2.100.12:8088">;
 
-fg_admin_traffic_3_traffic_switching_stackset_managed_test_cluster_zalan_do__resources__2_get: Path("/resources") && Method("GET") && HostAny("stackset-managed-test.cluster.zalan.do", "stackset-managed-test.cluster.zalan.do:443") && Header("X-Forwarded-Proto", "https") && Weight(5) && JWTPayloadAllKV("https://identity.zalando.com/realm", "users") && JWTPayloadAnyKV("https://identity.zalando.com/managed-id", "bmooney")
+fg_admin_traffic_3_traffic_switching_stackset_managed_test_cluster_zalan_do__resources__2_get: Path("/resources") && Method("GET") && HostAny("stackset-managed-test.cluster.zalan.do", "stackset-managed-test.cluster.zalan.do:443") && Header("X-Forwarded-Proto", "https") && Weight(5) && JWTPayloadAnyKV("https://identity.zalando.com/realm", "users") && JWTPayloadAnyKV("https://identity.zalando.com/managed-id", "bmooney")
 	-> oauthTokeninfoAnyKV("realm", "/services", "realm", "/employees")
 	-> enableAccessLog(2, 4, 5)
 	-> oauthTokeninfoAllScope("uid")
@@ -248,7 +248,7 @@ fg_traffic_3_traffic_switching_stackset_managed_test_cluster_zalan_do__resources
 	-> forwardToken("X-TokenInfo-Forward", "uid", "scope", "realm")
 	-> <roundRobin, "http://10.2.100.10:8088", "http://10.2.100.11:8088", "http://10.2.100.12:8088">;
 
-fg_admin_traffic_3_traffic_switching_stackset_managed_test_cluster_zalan_do__resources__2_post: Path("/resources") && Method("POST") && HostAny("stackset-managed-test.cluster.zalan.do", "stackset-managed-test.cluster.zalan.do:443") && Header("X-Forwarded-Proto", "https") && Weight(5) && JWTPayloadAllKV("https://identity.zalando.com/realm", "users") && JWTPayloadAnyKV("https://identity.zalando.com/managed-id", "bmooney")
+fg_admin_traffic_3_traffic_switching_stackset_managed_test_cluster_zalan_do__resources__2_post: Path("/resources") && Method("POST") && HostAny("stackset-managed-test.cluster.zalan.do", "stackset-managed-test.cluster.zalan.do:443") && Header("X-Forwarded-Proto", "https") && Weight(5) && JWTPayloadAnyKV("https://identity.zalando.com/realm", "users") && JWTPayloadAnyKV("https://identity.zalando.com/managed-id", "bmooney")
 	-> oauthTokeninfoAnyKV("realm", "/services", "realm", "/employees")
 	-> enableAccessLog(2, 4, 5)
 	-> oauthTokeninfoAllScope("uid")
@@ -265,7 +265,7 @@ fg_traffic_3_traffic_switching_stackset_managed_test_cluster_zalan_do__resources
 	-> forwardToken("X-TokenInfo-Forward", "uid", "scope", "realm")
 	-> <roundRobin, "http://10.2.100.10:8088", "http://10.2.100.11:8088", "http://10.2.100.12:8088">;
 
-fg_admin_traffic_3_traffic_switching_stackset_managed_test_cluster_zalan_do__resources_sub__2_get: Path("/resources/sub") && Method("GET") && HostAny("stackset-managed-test.cluster.zalan.do", "stackset-managed-test.cluster.zalan.do:443") && Header("X-Forwarded-Proto", "https") && Weight(5) && JWTPayloadAllKV("https://identity.zalando.com/realm", "users") && JWTPayloadAnyKV("https://identity.zalando.com/managed-id", "bmooney")
+fg_admin_traffic_3_traffic_switching_stackset_managed_test_cluster_zalan_do__resources_sub__2_get: Path("/resources/sub") && Method("GET") && HostAny("stackset-managed-test.cluster.zalan.do", "stackset-managed-test.cluster.zalan.do:443") && Header("X-Forwarded-Proto", "https") && Weight(5) && JWTPayloadAnyKV("https://identity.zalando.com/realm", "users") && JWTPayloadAnyKV("https://identity.zalando.com/managed-id", "bmooney")
 	-> oauthTokeninfoAnyKV("realm", "/services", "realm", "/employees")
 	-> enableAccessLog(2, 4, 5)
 	-> oauthTokeninfoAllScope("uid")
@@ -282,7 +282,7 @@ fg_traffic_3_traffic_switching_stackset_managed_test_ingress_cluster_local__reso
 	-> forwardToken("X-TokenInfo-Forward", "uid", "scope", "realm")
 	-> <roundRobin, "http://10.2.100.10:8088", "http://10.2.100.11:8088", "http://10.2.100.12:8088">;
 
-fg_admin_traffic_3_traffic_switching_stackset_managed_test_ingress_cluster_local__resources__2_get: Path("/resources") && Method("GET") && HostAny("stackset-managed-test.ingress.cluster.local", "stackset-managed-test.ingress.cluster.local:80") && Weight(5) && JWTPayloadAllKV("https://identity.zalando.com/realm", "users") && JWTPayloadAnyKV("https://identity.zalando.com/managed-id", "bmooney")
+fg_admin_traffic_3_traffic_switching_stackset_managed_test_ingress_cluster_local__resources__2_get: Path("/resources") && Method("GET") && HostAny("stackset-managed-test.ingress.cluster.local", "stackset-managed-test.ingress.cluster.local:80") && Weight(5) && JWTPayloadAnyKV("https://identity.zalando.com/realm", "users") && JWTPayloadAnyKV("https://identity.zalando.com/managed-id", "bmooney")
 	-> oauthTokeninfoAnyKV("realm", "/services", "realm", "/employees")
 	-> enableAccessLog(2, 4, 5)
 	-> oauthTokeninfoAllScope("uid")
@@ -299,7 +299,7 @@ fg_traffic_3_traffic_switching_stackset_managed_test_ingress_cluster_local__reso
 	-> forwardToken("X-TokenInfo-Forward", "uid", "scope", "realm")
 	-> <roundRobin, "http://10.2.100.10:8088", "http://10.2.100.11:8088", "http://10.2.100.12:8088">;
 
-fg_admin_traffic_3_traffic_switching_stackset_managed_test_ingress_cluster_local__resources__2_post: Path("/resources") && Method("POST") && HostAny("stackset-managed-test.ingress.cluster.local", "stackset-managed-test.ingress.cluster.local:80") && Weight(5) && JWTPayloadAllKV("https://identity.zalando.com/realm", "users") && JWTPayloadAnyKV("https://identity.zalando.com/managed-id", "bmooney")
+fg_admin_traffic_3_traffic_switching_stackset_managed_test_ingress_cluster_local__resources__2_post: Path("/resources") && Method("POST") && HostAny("stackset-managed-test.ingress.cluster.local", "stackset-managed-test.ingress.cluster.local:80") && Weight(5) && JWTPayloadAnyKV("https://identity.zalando.com/realm", "users") && JWTPayloadAnyKV("https://identity.zalando.com/managed-id", "bmooney")
 	-> oauthTokeninfoAnyKV("realm", "/services", "realm", "/employees")
 	-> enableAccessLog(2, 4, 5)
 	-> oauthTokeninfoAllScope("uid")
@@ -316,7 +316,7 @@ fg_traffic_3_traffic_switching_stackset_managed_test_ingress_cluster_local__reso
 	-> forwardToken("X-TokenInfo-Forward", "uid", "scope", "realm")
 	-> <roundRobin, "http://10.2.100.10:8088", "http://10.2.100.11:8088", "http://10.2.100.12:8088">;
 
-fg_admin_traffic_3_traffic_switching_stackset_managed_test_ingress_cluster_local__resources_sub__2_get: Path("/resources/sub") && Method("GET") && HostAny("stackset-managed-test.ingress.cluster.local", "stackset-managed-test.ingress.cluster.local:80") && Weight(5) && JWTPayloadAllKV("https://identity.zalando.com/realm", "users") && JWTPayloadAnyKV("https://identity.zalando.com/managed-id", "bmooney")
+fg_admin_traffic_3_traffic_switching_stackset_managed_test_ingress_cluster_local__resources_sub__2_get: Path("/resources/sub") && Method("GET") && HostAny("stackset-managed-test.ingress.cluster.local", "stackset-managed-test.ingress.cluster.local:80") && Weight(5) && JWTPayloadAnyKV("https://identity.zalando.com/realm", "users") && JWTPayloadAnyKV("https://identity.zalando.com/managed-id", "bmooney")
 	-> oauthTokeninfoAnyKV("realm", "/services", "realm", "/employees")
 	-> enableAccessLog(2, 4, 5)
 	-> oauthTokeninfoAllScope("uid")


### PR DESCRIPTION
refactor: use dataclient members to set filters/predicates and identify svc/user/admin and authorize them
 via Options

Signed-off-by: Sandor Szücs <sandor.szuecs@zalando.de>